### PR TITLE
Updated Ubuntu script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Paste this script into a Terminal prompt:
 bash <(curl -sL https://raw.githubusercontent.com/GA-WDI/installfest/master/builds/mac)
 ```
 
-##### ~~For Ubuntu Linux~~
+##### For Ubuntu Linux
 
 Paste this script into a Terminal prompt:
 
@@ -45,9 +45,10 @@ Paste this script into a Terminal prompt:
 bash <(wget -qO- https://raw.githubusercontent.com/lizrodriguez/installfest/master/builds/ubuntu)
 ```
 
-*Sadly, the Ubuntu script is out of date and is not currently 
+~~~*Sadly, the Ubuntu script is out of date and is not currently 
 supported. If you'd like to help get it back in to working order, let us
-know!*
+know!*~~~
+I was able to update this script to install the newest version of Ruby, Node and NVM as of 11/12/17. (I hardcoded the version number for Node since the newest (9.1.0) doesn't work with npm.)
 
 ##### Run the script
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Paste this script into a Terminal prompt:
 bash <(wget -qO- https://raw.githubusercontent.com/lizrodriguez/installfest/master/builds/ubuntu)
 ```
 
-I was able to update this script for Ubuntu. It installs the newest version of Ruby, Node and NVM as Nov 2017. (I hardcoded the version number for Node since the newest (9.1.0) doesn't work with npm.)
+I was able to update this script for Ubuntu. It installs the newest version of Sublime Text 3, Ruby, Node and NVM as Nov 2017. (I hardcoded the version number for Node since the newest (9.1.0) doesn't work with npm.)
 
 ~~*Sadly, the Ubuntu script is out of date and is not currently 
 supported. If you'd like to help get it back in to working order, let us

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Paste this script into a Terminal prompt:
 bash <(wget -qO- https://raw.githubusercontent.com/lizrodriguez/installfest/master/builds/ubuntu)
 ```
 
-I was able to update this script for Ubuntu.  It installs the newest version of Ruby, Node and NVM as Nov 2017. (I hardcoded the version number for Node since the newest (9.1.0) doesn't work with npm.)
+I was able to update this script for Ubuntu. It installs the newest version of Ruby, Node and NVM as Nov 2017. (I hardcoded the version number for Node since the newest (9.1.0) doesn't work with npm.)
 
-~~~*Sadly, the Ubuntu script is out of date and is not currently 
+~~*Sadly, the Ubuntu script is out of date and is not currently 
 supported. If you'd like to help get it back in to working order, let us
-know!*~~~
+know!*~~
 
 ##### Run the script
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ bash <(wget -qO- https://raw.githubusercontent.com/lizrodriguez/installfest/mast
 ~~~*Sadly, the Ubuntu script is out of date and is not currently 
 supported. If you'd like to help get it back in to working order, let us
 know!*~~~
-I was able to update this script to install the newest version of Ruby, Node and NVM as of 11/12/17. (I hardcoded the version number for Node since the newest (9.1.0) doesn't work with npm.)
+
+I was able to update this script for Ubuntu.  It installs the newest version of Ruby, Node and NVM as Nov 2017. (I hardcoded the version number for Node since the newest (9.1.0) doesn't work with npm.)
 
 ##### Run the script
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Paste this script into a Terminal prompt:
 bash <(wget -qO- https://raw.githubusercontent.com/lizrodriguez/installfest/master/builds/ubuntu)
 ```
 
+I was able to update this script for Ubuntu.  It installs the newest version of Ruby, Node and NVM as Nov 2017. (I hardcoded the version number for Node since the newest (9.1.0) doesn't work with npm.)
+
 ~~~*Sadly, the Ubuntu script is out of date and is not currently 
 supported. If you'd like to help get it back in to working order, let us
 know!*~~~
-
-I was able to update this script for Ubuntu.  It installs the newest version of Ruby, Node and NVM as Nov 2017. (I hardcoded the version number for Node since the newest (9.1.0) doesn't work with npm.)
 
 ##### Run the script
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ bash <(curl -sL https://raw.githubusercontent.com/GA-WDI/installfest/master/buil
 
 ##### ~~For Ubuntu Linux~~
 
-~~Paste this script into a Terminal prompt:~~
+Paste this script into a Terminal prompt:
 
-~~`bash <(wget -qO- https://raw.githubusercontent.com/GA-WDI/installfest/master/builds/ubuntu)`~~
+```
+bash <(wget -qO- https://raw.githubusercontent.com/lizrodriguez/installfest/master/builds/ubuntu)
+```
 
 *Sadly, the Ubuntu script is out of date and is not currently 
 supported. If you'd like to help get it back in to working order, let us

--- a/builds/mac
+++ b/builds/mac
@@ -41,8 +41,8 @@ COMPILED_AT='Mon Sep 26 14:44:46 PDT 2016'
 
 # FIXME (PJ) should have a better place to decide these versions:
 #   Ruby (rbenv), Python (pyenv), Node (nvm)
-BELOVED_RUBY_VERSION="2.2.3"
-CURRENT_STABLE_RUBY_VERSION="2.2.3"
+BELOVED_RUBY_VERSION="2.4.2"
+CURRENT_STABLE_RUBY_VERSION="2.4.2"
 
 # TODO (pj) decide what the python versions should really be...
 #   and maybe come up with a bigger, better place to hang this info
@@ -64,7 +64,7 @@ fi
 SCRIPT_ROOT="$HOME/.wdi"
 
 # TODO (PJ) this needs to be more robust, BY FAR!
-SCRIPT_REPO="https://github.com/GA-WDI/installfest_script.git"
+SCRIPT_REPO="https://github.com/lizrodriguez/installfest.git"
 SCRIPT_REPO_BRANCH="master"
 
 # the downloaded repo
@@ -78,7 +78,7 @@ SCRIPT_SUBL_PACKAGES=$SCRIPT_SETTINGS/sublime_packages/*
 SCRIPT_THEMES=$SCRIPT_SETTINGS/terminal/*
 
 # the working folder
-STUDENT_FOLDER="$HOME/code/wdi"
+STUDENT_FOLDER="$HOME/code/"
 
 # Deprecated as part of the utils/report_log.sh system...
 # TODO (PJ) update how reporting is done?

--- a/builds/ubuntu
+++ b/builds/ubuntu
@@ -57,7 +57,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   BASH_FILE=".bash_profile"
   MINIMUM_MAC_OS="10.7.0"
 else
-  SYSTEM="ubuntu"
+  SYSTEM="linux"
   BASH_FILE=".bashrc"
 fi
 

--- a/builds/ubuntu
+++ b/builds/ubuntu
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-COMPILED_AT='Mon Sep 26 14:44:46 PDT 2016'
+#COMPILED_AT='Mon Sep 26 14:44:46 PDT 2016'
 #
 #  _           _        _ _  __           _
 # (_)_ __  ___| |_ __ _| | |/ _| ___  ___| |_
@@ -41,13 +41,13 @@ COMPILED_AT='Mon Sep 26 14:44:46 PDT 2016'
 
 # FIXME (PJ) should have a better place to decide these versions:
 #   Ruby (rbenv), Python (pyenv), Node (nvm)
-BELOVED_RUBY_VERSION="2.2.3"
-CURRENT_STABLE_RUBY_VERSION="2.2.3"
+BELOVED_RUBY_VERSION="2.4.2"
+CURRENT_STABLE_RUBY_VERSION="2.4.2"
 
 # TODO (pj) decide what the python versions should really be...
 #   and maybe come up with a bigger, better place to hang this info
 BELOVED_PYTHON_VERSION="anaconda-2.0.1"
-CURRENT_STABLE_PYTHON_VERSION="3.4.1"
+CURRENT_STABLE_PYTHON_VERSION="3.6.3"
 
 # NOT BEING USED YET, BUT SHOULD!
 NODE_VERSION="stable" # using nvm's language...
@@ -64,7 +64,7 @@ fi
 SCRIPT_ROOT="$HOME/.wdi"
 
 # TODO (PJ) this needs to be more robust, BY FAR!
-SCRIPT_REPO="https://github.com/GA-WDI/installfest_script.git"
+SCRIPT_REPO="https://github.com/lizrodriguez/installfest.git"
 SCRIPT_REPO_BRANCH="master"
 
 # the downloaded repo
@@ -78,7 +78,7 @@ SCRIPT_SUBL_PACKAGES=$SCRIPT_SETTINGS/sublime_packages/*
 SCRIPT_THEMES=$SCRIPT_SETTINGS/terminal/*
 
 # the working folder
-STUDENT_FOLDER="$HOME/code/wdi"
+STUDENT_FOLDER="$HOME/code/"
 
 # Deprecated as part of the utils/report_log.sh system...
 # TODO (PJ) update how reporting is done?
@@ -604,7 +604,7 @@ sudo apt-get -y install google-chrome-stable
 # sudo apt-get -y install hipchat
 
 # sublime
-sudo add-apt-repository -y ppa:webupd8team/sublime-text-2
+sudo add-apt-repository -y ppa:webupd8team/sublime-text-3
 sudo apt-get -y update
 sudo apt-get -y install sublime-text
 

--- a/builds/ubuntu
+++ b/builds/ubuntu
@@ -565,7 +565,11 @@ if [[ -e "$NVM_DIR" ]]; then
   show "Already installed. Moving on..."
 else
   # install Node Version Manager
-  git clone https://github.com/creationix/nvm.git "$NVM_DIR" && cd "$NVM_DIR" && git checkout `git describe --abbrev=0 --tags`
+  #git clone https://github.com/creationix/nvm.git "$NVM_DIR" && cd "$NVM_DIR" && git checkout `git describe --abbrev=0 --tags`
+  curl -sL https://raw.githubusercontent.com/creationix/nvm/v0.31.0/install.sh -o install_nvm.sh
+
+  bash install_nvm.sh
+
   show "Complete!"
 fi
 
@@ -589,7 +593,7 @@ show "Complete!"
 
 # Google Chrome.........The Browser
 # HipChat...............The Chat Client
-# Sublime Text 2........The Text Editor
+# Sublime Text 3........The Text Editor
 
 # chrome
 sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'

--- a/builds/ubuntu
+++ b/builds/ubuntu
@@ -50,7 +50,7 @@ BELOVED_PYTHON_VERSION="anaconda-2.0.1"
 CURRENT_STABLE_PYTHON_VERSION="3.6.3"
 
 # NOT BEING USED YET, BUT SHOULD!
-NODE_VERSION="stable" # using nvm's language...
+NODE_VERSION="8.9.1" # using nvm's language...
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   SYSTEM="mac"

--- a/settings/sublime_settings/Preferences.sublime-settings
+++ b/settings/sublime_settings/Preferences.sublime-settings
@@ -1,7 +1,7 @@
 {
   "bold_folder_labels": true,
   "close_windows_when_empty": true,
-  "color_scheme": "Packages/Color Scheme - Default/Solarized (Light).tmTheme",
+  "color_scheme": "Packages/Color Scheme - Default/Solarized (Dark).tmTheme",
   "default_line_ending": "unix",
   "drag_text": false,
   "draw_white_space": "selection",


### PR DESCRIPTION
Hi! I've made some minor changes to the install script so that installfest runs on Ubuntu 16.04 LTS. It installs the newest version of Sublime Text 3, Ruby, Node and NVM as Nov 2017. (I hard coded the version number for Node since the newest 9.1.0 doesn't work with npm.) If this pull request is approved, the script may need to be changed back to "SCRIPT_REPO="https://github.com/GA-WDI/installfest_script.git" instead of my account. 